### PR TITLE
Add support for regex in assert logged

### DIFF
--- a/lib/chore_runner/chore_case.ex
+++ b/lib/chore_runner/chore_case.ex
@@ -3,16 +3,18 @@ defmodule ChoreRunner.ChoreCase do
 
   using do
     quote do
-      defmacro assert_logged(log) do
+      defmacro assert_logged(log, opts \\ []) do
+        exact_match? = Keyword.get(opts, :exact, false)
         quote do
           assert Process.get(ChoreRunner.Reporter.__process_dict_key__())
                  |> GenServer.call(
                    {:assert_logged,
                     fn
                       {:log, log, _} ->
-                        case unquote(log) do
-                          %Regex{} = regex -> log =~ regex
-                          bin when is_binary(bin) -> log == bin
+                        if unquote(exact_match?) do
+                          log == unquote(log)
+                        else
+                          log =~ unquote(log)
                         end
 
                       _ ->

--- a/lib/chore_runner/chore_case.ex
+++ b/lib/chore_runner/chore_case.ex
@@ -10,7 +10,10 @@ defmodule ChoreRunner.ChoreCase do
                    {:assert_logged,
                     fn
                       {:log, log, _} ->
-                        log == unquote(log)
+                        case unquote(log) do
+                          %Regex{} = regex -> log =~ regex
+                          bin when is_binary(bin) -> log == bin
+                        end
 
                       _ ->
                         false


### PR DESCRIPTION
Update `ChoreRunner.ChoreCase.assert_logged/1` macro to `ChoreRunner.ChoreCase.assert_logged/2` where the second param is a keyword list of options. Currently only supporting `exact: boolean()`. If `exact: true` then the string will be matched using `==`. if `exact: false` (Default if not provided) then the string will be matched using `=~` which also works with regex.

Examples
```elixir
# log =~ "test"
assert_logged("test")

# log =~ "test"
assert_logged("test", exact: false)

# log == "test"
assert_logged("test", exact: true)
```